### PR TITLE
Makefile: respect $LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ OBJS=$(MODULES:=.o)
 all: $(PROG)
 
 $(PROG): $(OBJS)  $(HDRS)
-	$(CC) -o $(PROG) $(OBJS)
+	$(CC) $(LDFLAGS) -o $(PROG) $(OBJS)
 
 clean:
 	rm -f *.o $(PROG) 


### PR DESCRIPTION
This is needed, e.g. to make a static build.